### PR TITLE
Add more styling to examples list view

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1,2 +1,27 @@
-table tbody tr:nth-child(odd)   { background-color:#eee; }
-table tbody tr:nth-child(even)    { background-color:#fff; }
+body {
+  margin: 0 auto;
+  padding: 0 1em 3em;
+  max-width: 80em;
+  color: #111;
+  background: #fff;
+  font: medium 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+table th,
+table td {
+  padding: .75em 1.2em;
+  border-bottom: 1px solid #ddd;
+}
+
+table th {
+  text-align: left;
+  border-bottom: 2px solid #ddd;
+}
+
+table tbody tr:nth-child(odd) {
+  background-color: #fafafa;
+}


### PR DESCRIPTION
Some basic typography and whitespace to make it a bit more readable

![dummy content store examples list](https://cloud.githubusercontent.com/assets/63201/10245825/3f1d2e0e-6903-11e5-827a-b0df96ccf205.png)

@heathd 
