### PR TITLE
Make port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,19 @@ Start the server using:
 
     $ dummy_content_store
 
-By default it will look for the schemas:
+It will look for the schema files in the following locations:
 
   1. at the path specified by the `GOVUK_CONTENT_SCHEMAS_PATH` environment variable
   2. in the current directory
   3. at the path specified in the first argument
+
+## Configuration
+
+By default the dummy content store runs on port 3068 which is the same port as
+content store. If you want run it on a different port you can configure it
+using the `PORT` environment variable:
+
+    $ PORT=9999 dummy_content_store
 
 ## Contributing
 

--- a/bin/dummy_content_store
+++ b/bin/dummy_content_store
@@ -16,4 +16,4 @@ if ARGV.size == 1
   ENV['GOVUK_CONTENT_SCHEMAS_PATH'] = ARGV.first
 end
 
-Rack::Server.start(config: File.dirname(__FILE__) + "/../config.ru")
+Rack::Server.start(config: File.dirname(__FILE__) + "/../config.ru", Port: ENV['PORT'] || 3068)

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,3 @@
-#\ -p 3068
 $LOAD_PATH << File.dirname(__FILE__) + "/lib"
 require 'govuk/dummy_content_store'
 


### PR DESCRIPTION
allow the `PORT` environment variable to be used to configure
the port which the service runs on. This is the env var set by Heroku
so it should run out of the box there.

If `PORT` is not set, defaults to 3068.
