### PR TITLE
Only include front-end examples

### DIFF
--- a/lib/govuk/dummy_content_store/example_repository.rb
+++ b/lib/govuk/dummy_content_store/example_repository.rb
@@ -20,7 +20,7 @@ module Govuk
 
     private
       def all_example_paths
-        Dir[content_schemas_path + "formats" + "**" + "examples" + "*.json"]
+        Dir[content_schemas_path + "formats" + "*" + "frontend" + "examples" + "*.json"]
       end
     end
   end


### PR DESCRIPTION
The dummy content store was also including the `publishing_v2` examples.
- Don’t ever show publishing_v2 examples
- Avoid the clash of base paths when publising_v2 example matches the
  front-end one
# Before

![screen shot 2016-02-02 at 11 56 19](https://cloud.githubusercontent.com/assets/319055/12748766/54e33c86-c9a4-11e5-8258-e0cf7ea1cdf9.png)
# After

![screen shot 2016-02-02 at 11 56 03](https://cloud.githubusercontent.com/assets/319055/12748764/530f01ec-c9a4-11e5-99a4-7a29545c558f.png)
