### PR TITLE
Fall back to the live content store

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ It will look for the schema files in the following locations:
   2. in the current directory
   3. at the path specified in the first argument
 
+If a fallback url is specified on startup:
+
+    $ dummy_content_store -u https://www.gov.uk/api/content
+
+  or 
+
+    $ DUMMY_CONTENT_STORE_FALLBACK_URL=https://www.gov.uk/api/content dummy_content_store
+
+it will look also for live contents at the specified url, if the example content is not found.
+
 ## Configuration
 
 By default the dummy content store runs on port 3068 which is the same port as

--- a/bin/dummy_content_store
+++ b/bin/dummy_content_store
@@ -10,6 +10,13 @@ OptionParser.new do |opts|
     puts opts
     exit
   end
+
+  opts.on('-u', '--url URL', "Fallback URL for non available examples") do |url|
+    # e.g. https://www.gov.uk/api/content
+    ENV["DUMMY_CONTENT_STORE_FALLBACK_URL"] = url
+    puts "fallback URL = #{url}"
+  end
+
 end.parse!
 
 if ARGV.size == 1

--- a/config.ru
+++ b/config.ru
@@ -2,7 +2,10 @@ $LOAD_PATH << File.dirname(__FILE__) + "/lib"
 require 'govuk/dummy_content_store'
 
 govuk_content_schemas_path = ENV.fetch('GOVUK_CONTENT_SCHEMAS_PATH', ".")
+govuk_live_content_path = ENV['DUMMY_CONTENT_STORE_FALLBACK_URL']
+
 repository = Govuk::DummyContentStore::ExampleRepository.new(govuk_content_schemas_path)
+live_repository = Govuk::DummyContentStore::LiveRepository.new(govuk_live_content_path) if govuk_live_content_path
 
 map '/' do
   run Govuk::DummyContentStore::Index.new(repository)
@@ -18,10 +21,10 @@ end
 
 # Serve examples
 map '/content' do
-  run Govuk::DummyContentStore::Content.new(repository)
+  run Govuk::DummyContentStore::Content.new(repository, live_repository)
 end
 map '/api/content' do
-  run Govuk::DummyContentStore::Content.new(repository)
+  run Govuk::DummyContentStore::Content.new(repository, live_repository)
 end
 
 

--- a/govuk-dummy_content_store.gemspec
+++ b/govuk-dummy_content_store.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "gem_publisher"
   spec.add_development_dependency "nokogiri"
+  spec.add_development_dependency "webmock"
 end

--- a/lib/govuk/dummy_content_store.rb
+++ b/lib/govuk/dummy_content_store.rb
@@ -5,6 +5,7 @@ module Govuk
     autoload :Content, "govuk/dummy_content_store/content"
     autoload :ExampleContentItem, "govuk/dummy_content_store/example_content_item"
     autoload :ExampleRepository, "govuk/dummy_content_store/example_repository"
+    autoload :LiveRepository, "govuk/dummy_content_store/live_repository"
     autoload :Index, "govuk/dummy_content_store/index"
   end
 end

--- a/lib/govuk/dummy_content_store/live_repository.rb
+++ b/lib/govuk/dummy_content_store/live_repository.rb
@@ -1,0 +1,25 @@
+module Govuk
+  module DummyContentStore
+    class LiveRepository
+      attr_reader :live_content_path
+
+      def initialize(live_content_path)
+        @live_content_path = live_content_path
+      end
+
+      def find_by_base_path(base_path)
+        res = http_get(base_path)
+        res.code == "404" ? nil : res
+      end
+
+    private
+      def http_get(base_path)
+        url = URI.parse(live_content_path + base_path)
+        req = Net::HTTP::Get.new(url.to_s)
+        http = Net::HTTP.new(url.host, url.port)
+        http.use_ssl = true if url.scheme == "https"
+        http.request(req)
+      end
+    end
+  end
+end

--- a/spec/integration/dummy_content_store_spec.rb
+++ b/spec/integration/dummy_content_store_spec.rb
@@ -65,4 +65,28 @@ RSpec.describe "Dummy content store rack application" do
       expect(last_response).to be_ok
     end
   end
+
+  
+  context "a fallback url is set" do
+    before(:each) { ENV['DUMMY_CONTENT_STORE_FALLBACK_URL'] = "https://www.gov.uk/api/content" }
+    
+    it "serves the live content if the example is not available" do
+      live_file_base_path = "/available"
+      live_content_body = "stubbed response"
+    
+      get "/api/content#{live_file_base_path}"
+      expect(last_response).to be_ok
+      expect(last_response.body).to eq(live_content_body)
+    end
+
+    it "responds not found if both live and example are not available" do
+      live_file_base_path = "/not-available"
+      not_found_body = "Not found"
+      
+      get "/api/content#{live_file_base_path}"
+      expect(last_response).not_to be_ok
+      expect(last_response.status).to eq(404)
+      expect(last_response.body).to eq(not_found_body)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'webmock/rspec'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -18,4 +20,14 @@ RSpec.configure do |config|
   config.order = :random
 
   Kernel.srand config.seed
+
+  config.before(:each) do
+    stub_request(:get, "https://www.gov.uk/api/content/available").
+      with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+      to_return(status: 200, body: "stubbed response", headers: {})
+
+    stub_request(:get, "https://www.gov.uk/api/content/not-available").
+      with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+      to_return(status: 404, body: "not found", headers: {})
+  end
 end


### PR DESCRIPTION
The dummy content store contains a limited set of examples of frontend documents. 

With this PR it can fall back to serving content from the live content store if the requested URL is not available in the examples.
