### PR TITLE
Fix display of the schema name

### DIFF
--- a/lib/govuk/dummy_content_store/example_content_item.rb
+++ b/lib/govuk/dummy_content_store/example_content_item.rb
@@ -17,8 +17,8 @@ module Govuk
         data["base_path"]
       end
 
-      def format
-        data["format"]
+      def schema_name
+        data["schema_name"]
       end
 
       def title

--- a/lib/govuk/dummy_content_store/templates/index.html.erb
+++ b/lib/govuk/dummy_content_store/templates/index.html.erb
@@ -15,7 +15,7 @@
       <table>
         <thead>
           <tr>
-            <th>Format</th>
+            <th>Schema</th>
             <th>Filename</th>
             <th>Title</th>
           </tr>
@@ -24,7 +24,7 @@
         <tbody>
           <% examples.each do |example| %>
             <tr>
-              <td><%= h(example.format) %></a></td>
+              <td><%= h(example.schema_name) %></a></td>
               <td><%= h(example.filename) %></a></td>
               <td><a href="<%= h(example.view_url) %>"><%= h(example.title) %></a></td>
             </tr>
@@ -34,4 +34,3 @@
 
     </body>
 </html>
-


### PR DESCRIPTION
The field `format` has been deprecated and will be removed soon.

## Before

![screen shot 2016-12-09 at 14 26 17](https://cloud.githubusercontent.com/assets/233676/21052195/94441fdc-be1b-11e6-8d11-07b6b23ae752.png)

## After

![screen shot 2016-12-09 at 14 26 29](https://cloud.githubusercontent.com/assets/233676/21052185/81f2b46a-be1b-11e6-834e-9932fce0ef45.png)
